### PR TITLE
Add CWD option.

### DIFF
--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -30,6 +30,11 @@
         args.push(f.dest);
       }
 
+      var origCwd = process.cwd();
+      if (f.cwd) {
+        grunt.file.setBase(f.cwd);
+      }
+
       var drush = grunt.util.spawn({
         cmd: 'drush',
         args: args
@@ -45,6 +50,8 @@
 
       drush.stdout.pipe(process.stdout);
       drush.stderr.pipe(process.stderr);
+
+      grunt.file.setBase(origCwd);
     }, cb);
   });
 };


### PR DESCRIPTION
Many drush commands, such as drush cc all, drush features revert, etc., need to be done within the drupal directory. Adding the ability to specify the cwd directory for a drush command would allow those to be run as well.
