### PR TITLE
Removed the dependency for grunt-lib-contrib because it is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.1",
-    "grunt-lib-contrib": "~0.6.1"
+    "grunt": "~0.4.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -13,7 +13,6 @@
   var fs   = require('fs'),
   path = require('path');
   var _ = grunt.util._;
-  var helpers = require('grunt-lib-contrib').init(grunt);
   var self = this;
 
   grunt.registerMultiTask('drush', 'Drush task runner for grunt.', function() {


### PR DESCRIPTION
I have removed the dependency from the package.json and the drush.js task as grunt-lib-contrib is deprecated (see https://github.com/gruntjs/grunt-lib-contrib).

The command still works as expected (according to my limited testing).
