### PR TITLE
Properly check if dest is undefined.

### DIFF
--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -25,7 +25,7 @@
     grunt.util.async.forEachSeries(this.files, function(f, next) {
       args = [].concat(f.args);
 
-      if (f.dest !== 'undefined') {
+      if (typeof f.dest !== 'undefined') {
         args.push(f.dest);
       }
 


### PR DESCRIPTION
Otherwise if f.dest is actually undefined args will look something like `['cc', 'all', undefined]`.