### PR TITLE
Explicitly set "files" key in drush tasks.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
     drush: {
       install: {
         args: ['make', 'example/core.make'],
-        dest: 'src'
+        files: [{ dest: 'src' }]
       }
     }
   });

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -16,22 +16,12 @@
   var self = this;
 
   grunt.registerMultiTask('drush', 'Drush task runner for grunt.', function() {
-    var cb = this.async();
     var options = this.options();
-    var args;
-
-    grunt.verbose.writeflags(options, 'Options');
-
-    grunt.util.async.forEachSeries(this.files, function(f, next) {
-      args = [].concat(f.args);
-
-      if (f.dest !== 'undefined') {
-        args.push(f.dest);
-      }
-
+    var args = this.data.args;
+    var callDrush = function(args) {
       var origCwd = process.cwd();
-      if (f.cwd) {
-        grunt.file.setBase(f.cwd);
+      if (options.cwd) {
+        grunt.file.setBase(options.cwd);
       }
 
       var drush = grunt.util.spawn({
@@ -42,15 +32,29 @@
           return grunt.warn(
             'You need to have drush installed and in your PATH for\n' +
             'this task to work.'
-            );
+          );
         }
-        next(error);
       });
 
       drush.stdout.pipe(process.stdout);
       drush.stderr.pipe(process.stderr);
 
       grunt.file.setBase(origCwd);
-    }, cb);
+    };
+
+    if (this.files.length === 0) {
+      callDrush(args);
+    }
+    else {
+      this.files.forEach(function(file) {
+        var fileArgs;
+
+        if (file.dest !== 'undefined') {
+          fileArgs = args.concat([file.dest]);
+        }
+
+        callDrush(fileArgs);
+      });
+    }
   });
 };

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -49,7 +49,7 @@
       this.files.forEach(function(file) {
         var fileArgs;
 
-        if (file.dest !== 'undefined') {
+        if (typeof file.dest !== 'undefined') {
           fileArgs = args.concat([file.dest]);
         }
 


### PR DESCRIPTION
By setting "files" separately from "args" and "cwd", these options can
be applied to each file that may be given in the task. A separate, but
identically configured Drush process is started for each destination
file.

Fixes #7.