### PR TITLE
Use "cmd" option to specify path to drush.

### DIFF
--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -15,6 +15,8 @@
   var _ = grunt.util._;
   var self = this;
 
+  var cmd = grunt.config('drush.cmd') || 'drush';
+
   grunt.registerMultiTask('drush', 'Drush task runner for grunt.', function() {
     var cb = this.async();
     var options = this.options();
@@ -35,7 +37,7 @@
       }
 
       var drush = grunt.util.spawn({
-        cmd: 'drush',
+        cmd: cmd,
         args: args
       }, function(error, result, code) {
         if (code === 127) {


### PR DESCRIPTION
As it stands, grunt-drush lets the system decide where to find the drush executable, which is entirely reasonable for testing itself. But for projects that use Composer to download Drush and Grunt to run it, it is preferable to configure it so that the build tools are using the same versions on everyone's machine.