### PR TITLE
Get cmd from options and correctly handle cb().

### DIFF
--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -28,6 +28,7 @@
         cb = this.async();
 
     grunt.verbose.writeflags(options, 'Options');
+    grunt.verbose.writeflags(args, 'Args');
 
     var callDrush = function(args) {
 

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -45,7 +45,7 @@
 
         switch (code) {
           case 127:
-            drushResult = grunt.fatal(
+            grunt.fatal(
               'You need to have drush installed in your PATH\n' +
               'or set it in the configuration for this task to work.'
             );
@@ -56,40 +56,21 @@
             break;
 
           default:
-            drushResult = grunt.warn('Drush failed: ' + code);
+            grunt.warn('Drush failed: ' + code);
             break;
         }
 
-        cb();
+        drushResult = code === 0 || false;
+        grunt.verbose.writeln("Drush returned " + code);
 
-        return drushResult;
-
+        cb(drushResult);
       });
 
       grunt.file.setBase(origCwd);
 
     };
 
-    var processFiles = function() {
-
-      async.eachLimit(self.files, concurrencyLevel, function (file, next) {
-        var fileArgs;
-
-        if (_.isString(file.dest)) {
-          fileArgs = args.concat([file.dest]);
-        }
-
-        callDrush(fileArgs);
-      });
-
-    };
-
-    if (_.isArray(this.files)) {
-      processFiles();
-    } else {
-      callDrush(args);
-    }
-
+    callDrush(args);
   });
 
 };

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -14,14 +14,16 @@
       fs = require('fs'),
       path = require('path'),
       spawn = require('win-spawn'),
-      cmd = grunt.config('drush.cmd') || 'drush',
       os = require('os'),
       async = require('async'),
       concurrencyLevel = (os.cpus().length || 1) * 2;
 
   grunt.registerMultiTask('drush', 'Drush task runner for grunt.', function() {
     var self = this,
-        options = self.options(),
+        options = self.options({
+          cmd: 'drush',
+          cwd: false
+        }),
         args = self.data.args,
         cb = this.async();
 
@@ -36,7 +38,7 @@
         grunt.file.setBase(options.cwd);
       }
 
-      var cp = spawn(cmd, args, {stdio: 'inherit'});
+      var cp = spawn(options.cmd, args, {stdio: 'inherit'});
 
       cp.on('error', grunt.warn);
       cp.on('close', function (code) {
@@ -58,6 +60,8 @@
             break;
         }
 
+        cb();
+
         return drushResult;
 
       });
@@ -76,7 +80,7 @@
         }
 
         callDrush(fileArgs);
-      }, cb);
+      });
 
     };
 


### PR DESCRIPTION
This fixes the issue I raised [here](https://github.com/nickpack/grunt-drush/pull/10#issuecomment-68978639) and calls cb() in the proper place so multiple drush targets can be chained together (otherwise it would end after the first one).